### PR TITLE
削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit]
-  before_action :set_item, only: [:show,:edit,:update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :destroy]
+  before_action :set_item, only: [:show,:edit,:update,:destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -36,6 +36,12 @@ class ItemsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
+  end
+
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,8 +38,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item.destroy
-    redirect_to root_path
+    if @item.user == current_user
+      @item.destroy
+    end
+      redirect_to root_path
   end
 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", item_path , data: {turbo_method: :delete}, class:"item-destroy" %>
     <% end %>
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to:  "items#index"
-  resources :items, only:[:index,:new,:create,:show,:edit,:update]
+  resources :items
 end


### PR DESCRIPTION
# What
・商品情報削除機能に関するルーティング、コントローラー設定
・ログイン状態の場合にのみ、自身が出品した商品情報を削除できるようにbeforeアクションで実装

# Why
削除機能実装のため

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/12508cc4cb1f3511d315e2703e940993